### PR TITLE
fixes an issue with k3s networking

### DIFF
--- a/infra/scripts/branch-bicep/modules/k3s/control.bicep
+++ b/infra/scripts/branch-bicep/modules/k3s/control.bicep
@@ -14,7 +14,7 @@ var customData = base64(format('''
 #cloud-config
 package_upgrade: true
 runcmd:
-  - curl -sfL https://get.k3s.io | K3S_TOKEN={0} INSTALL_K3S_EXEC="server --disable traefik" sh -s -
+  - curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=v1.25.0-rc2+k3s1 K3S_TOKEN={0} INSTALL_K3S_EXEC="server --disable traefik" sh -s -
 ''',k3sToken))
 
 param name string

--- a/infra/scripts/branch-bicep/modules/k3s/workers.bicep
+++ b/infra/scripts/branch-bicep/modules/k3s/workers.bicep
@@ -29,7 +29,7 @@ var customData = base64(format('''
 #cloud-config
 package_upgrade: true
 runcmd:
-  - curl -sfL https://get.k3s.io | K3S_URL=https://{0}:6443 K3S_TOKEN={1} sh -s -
+  - curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=v1.25.0-rc2+k3s1 K3S_URL=https://{0}:6443 K3S_TOKEN={1} sh -s -
 ''',control,k3sToken))
 
 resource pubip 'Microsoft.Network/publicIPAddresses@2021-02-01' = {


### PR DESCRIPTION
This fixes networking issues with k3s on v1.24 as described here: https://github.com/k3s-io/k3s/issues/6047

For now, I've locked the version of k3s on v1.25.0-rc2+k3s1. In future releases of k3s we will have to bump this number up.

Previous version:
```
$ k3s -v
k3s version v1.24.4+k3s1 (c3f830e9)
go version go1.18.1
```
Flannel version:
```
$ sudo /var/lib/rancher/k3s/data/current/bin/flannel
CNI Plugin flannel version v0.19.1 (linux/amd64) commit c3f830e9b9ed8a4d9d0e2aa663b4591b923a296e built on 2022-08-25T03:45:26Z
```
We can see that there are no rules for masquerading on the nat chain

```bash
$ sudo iptables -vnL -t nat |grep 'masq'
$
```

After installing the new version, here's what we have.

k3s version:

```bash
reddogadmin@gbb1montreal-k3s-control:~$ k3s -v
k3s version v1.25.0-rc2+k3s1 (1d42f46c)
go version go1.19
```

flannel version
```
reddogadmin@gbb1montreal-k3s-control:~$ sudo /var/lib/rancher/k3s/data/current/bin/flannel
CNI Plugin flannel version v0.19.2 (linux/amd64) commit 1d42f46cda8b7603f43b4c3dcf1e8c13c5c6e014 built on 2022-09-07T20:23:36Z
```
and the iptables rules

```bash
reddogadmin@gbb1montreal-k3s-control:~$ sudo iptables -L -t nat | grep masq
RETURN     all  --  gbb1montreal-k3s-control/16  gbb1montreal-k3s-control/16  /* flanneld masq */
MASQUERADE  all  --  gbb1montreal-k3s-control/16 !base-address.mcast.net/4  /* flanneld masq */
RETURN     all  -- !gbb1montreal-k3s-control/16  gbb1montreal-k3s-control/24  /* flanneld masq */
MASQUERADE  all  -- !gbb1montreal-k3s-control/16  gbb1montreal-k3s-control/16  /* flanneld masq */
```