### PR TITLE
Fix various issues when creating a new branch

### DIFF
--- a/infra/Makefile
+++ b/infra/Makefile
@@ -14,7 +14,7 @@ help :
 all : hubinfra configurehub createbranches
 
 hubinfra :
-	mkdir logs
+	mkdir -p logs
 	./scripts/create-hub-infra.sh 2>&1 | tee -a ./logs/hub-deployment.log
 
 configurehub : 

--- a/infra/scripts/create-and-load-ssh-keys.sh
+++ b/infra/scripts/create-and-load-ssh-keys.sh
@@ -7,7 +7,7 @@ load_ssh_keys() {
 }
 
 # Check if the cleanup flag is passed, and ignore the ssh_key step
-if [[ ! -k $1 && $1 == "cleanup" ]]
+if [[ ${1+x} && $1 == "cleanup" ]]
 then
 	echo "Running cleanup. Don't generate ssh keys."
 else

--- a/infra/scripts/load-vars-from-config.sh
+++ b/infra/scripts/load-vars-from-config.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eou pipefail
 
 # Set Global Variables
 export CONFIG="$(cat config.json | jq -r .)"
@@ -22,12 +23,13 @@ export RABBIT_MQ_PASSWD="$(echo $CONFIG | jq -r '.rabbit_mq_passwd')"
 export REDIS_PASSWD="$(echo $CONFIG | jq -r '.redis_passwd')"
 
 # Get the current user Object ID
-if [[ $AZUREPS_HOST_ENVIRONMENT =~ ^cloud-shell.* ]]; then
-	# running in cloud-shell. We can use the information on ACC_OID
-	export CURRENT_USER_ID=$ACC_OID
-else
+# AZUREPS_HOST_ENVIRONMENT is only created inside of Cloud shell
+if [[ -z "${AZUREPS_HOST_ENVIRONMENT+x}" ]]; then
 	# running outside of cloud-shell. We need to retrieve the current user
 	export CURRENT_USER_ID=$(az ad signed-in-user show -o json| jq -r .id)
+elif [[ $AZUREPS_HOST_ENVIRONMENT =~ ^cloud-shell.* ]]; then
+	# running in cloud-shell. We can use the information on ACC_OID
+	export CURRENT_USER_ID=$ACC_OID
 fi
 
 


### PR DESCRIPTION
This PR proposes fixes to the following issue:

#50 - SQL Arc fails to deploy on branches
- remove log analytics uploads from az arcdata dc create
- make the Data Controller MSI an Owner in the branch resource group (previously, Contributor).
- fix the new syntax for the k8s endpoint in the az sql mi-arc show command (properties.k8_s_raw.status.endpoints.primary)

While here:

- Added a `-p` flag to the `mkdir` on `Makefile`. This allows for a user to run `make` multiple times (e.g.: when an error happens and there is a need to resume an activity).
- Bring back `set -eou pipefail` so we can fail if a variable is unbound. 
- Fix a few instances of unbounded variables
- Refactor how we check whether or not we are running in Azure Cloud Shell
- Make the `kubectl` commands that are remote executed through the jumpbox less prone to error out when an object is already present in the k3s cluster. Useful when trying to recreate a remote cluster.
- make sure `gitops_reddog_create` receives the proper `branch` flag when a branch is being created. This fixes an issue with an unbound variable.
- minor code refactoring on the `deploy_sql_arc()` function 

